### PR TITLE
Changed line 29 of secrets.yaml to deal with nil value when using Kuberntes 1.2.16

### DIFF
--- a/charts/o11y-service/Chart.yaml
+++ b/charts/o11y-service/Chart.yaml
@@ -5,6 +5,6 @@
 #
 apiVersion: v2
 name: o11yservice
-version: 1.2.28
+version: 1.2.29
 appVersion: "1.2.0"
 description: A helm chart for o11y service

--- a/charts/o11y-service/templates/secrets.yaml
+++ b/charts/o11y-service/templates/secrets.yaml
@@ -26,7 +26,7 @@ stringData:
 #metricsserver
 {{- if eq .Values.global.cp.resources.o11y.metricsServer.kind "prometheus" }}
   promserver-proxy-password: {{ quote .Values.global.cp.resources.o11y.metricsServer.secret.proxy.password }}
-  promserver-exporter-token: {{ quote .Values.global.cp.resources.o11y.metricsServer.secret.proxy.token }}
+  promserver-exporter-token: {{ quote .Values.global.cp.resources.o11y.metricsServer.secret.exporter.token }}
 {{- end }}
 {{- range $key, $value := .Values.global.cp.resources.o11y.logsServer.secret.exporter.userapp.headers }}
   headers-logs-expo-userapp-{{ $key }}: {{ quote $value }}


### PR DESCRIPTION
When working with Kubernetes version 1.21.6 

Line 29 changed from
  promserver-exporter-token: {{ quote .Values.global.cp.resources.o11y.metricsServer.secret.proxy.token }}
to
  promserver-exporter-token: {{ quote .Values.global.cp.resources.o11y.metricsServer.secret.exporter.token }}
Updated version o11y-Service helm chart version to 1.2.29