### PR TITLE
tibco-developer-hub 1.2.18

### DIFF
--- a/charts/bwprovisioner/Chart.yaml
+++ b/charts/bwprovisioner/Chart.yaml
@@ -4,7 +4,7 @@
 
 apiVersion: v2
 name: bwprovisioner
-version: 1.2.17
+version: 1.2.18
 appVersion: "1.2.0"
 description: TIBCO Platform Dataplane Capabilty -- BW Provisioner
 home: https://github.com/tibco/tp-iapp-bw-provisioner.git

--- a/charts/bwprovisioner/templates/ingress_public_nginx.yaml
+++ b/charts/bwprovisioner/templates/ingress_public_nginx.yaml
@@ -24,7 +24,7 @@ spec:
         path: {{ .Values.publicApi.ingress.nginx.pathPrefix }}/
         pathType: Prefix
 ---
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
   name: {{ $fullName }}-auth
@@ -43,7 +43,7 @@ spec:
       insecureSkipVerify: true
 ---
 # Source: {{ $fullName }}/templates/ingress_public_nginx.yaml
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
   name: {{ $fullName }}-rewrite

--- a/charts/dp-configure-namespace/Chart.yaml
+++ b/charts/dp-configure-namespace/Chart.yaml
@@ -5,5 +5,5 @@ apiVersion: v2
 name: dp-configure-namespace
 description: A Helm chart for creating service account, cluster-role, cluster-role-binding, role-binding & network-policies
 type: application
-version: 1.2.29
+version: 1.2.30
 appVersion: "1.2.0"

--- a/charts/dp-configure-namespace/templates/bwce-role.yaml
+++ b/charts/dp-configure-namespace/templates/bwce-role.yaml
@@ -57,7 +57,7 @@ rules:
 - apiGroups: ["configuration.konghq.com"]
   resources: ["kongplugins"]
   verbs: ["list", "get", "create", "update", "delete"]
-- apiGroups: ["traefik.containo.us"]
+- apiGroups: ["traefik.io"]
   resources: ["middlewares"]
   verbs: ["list", "get", "create", "update", "delete"]
 - apiGroups: ["coordination.k8s.io"]

--- a/charts/dp-configure-namespace/templates/devhub-role.yaml
+++ b/charts/dp-configure-namespace/templates/devhub-role.yaml
@@ -24,7 +24,7 @@ rules:
 - apiGroups: ["networking.k8s.io"]
   resources: ["ingresses"]
   verbs: ["create", "delete", "get", "update", "list"]
-- apiGroups: ["traefik.containo.us"]
+- apiGroups: ["traefik.io"]
   resources: ["middlewares"]
   verbs: ["list", "get", "create", "update", "delete"]
 

--- a/charts/dp-configure-namespace/templates/flogo-role.yaml
+++ b/charts/dp-configure-namespace/templates/flogo-role.yaml
@@ -57,7 +57,7 @@ rules:
 - apiGroups: ["configuration.konghq.com"]
   resources: ["kongplugins"]
   verbs: ["list", "get", "create", "update", "delete"]
-- apiGroups: ["traefik.containo.us"]
+- apiGroups: ["traefik.io"]
   resources: ["middlewares"]
   verbs: ["list", "get", "create", "update", "delete"]
 - apiGroups: ["coordination.k8s.io"]

--- a/charts/flogoprovisioner/Chart.yaml
+++ b/charts/flogoprovisioner/Chart.yaml
@@ -4,7 +4,7 @@
 
 apiVersion: v2
 name: flogoprovisioner
-version: 1.2.14
+version: 1.2.15
 appVersion: "1.2.0"
 description: TIBCO Platform Dataplane Capabilty -- Flogo Provisioner
 home: https://github.com/tibco/tp-iapp-flogo-provisioner.git

--- a/charts/flogoprovisioner/templates/ingress_public_nginx.yaml
+++ b/charts/flogoprovisioner/templates/ingress_public_nginx.yaml
@@ -24,7 +24,7 @@ spec:
         path: {{ .Values.publicApi.ingress.nginx.pathPrefix }}/
         pathType: Prefix
 ---
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
   name: {{ $fullName }}-auth
@@ -43,7 +43,7 @@ spec:
       insecureSkipVerify: true
 ---
 # Source: {{ $fullName }}/templates/ingress_public_nginx.yaml
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
   name: {{ $fullName }}-rewrite

--- a/charts/tibco-developer-hub/Chart.yaml
+++ b/charts/tibco-developer-hub/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.17
+version: 1.2.18
 
 appVersion: "1.2.0"
 

--- a/charts/tibco-developer-hub/templates/ingress.yaml
+++ b/charts/tibco-developer-hub/templates/ingress.yaml
@@ -45,7 +45,7 @@ spec:
                 port:
                   number: {{ .Values.service.ports.backend }}
 ---
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
   name: {{ $fullName }}-auth

--- a/charts/tibco-developer-hub/templates/well-known-configuration-ingress.yaml
+++ b/charts/tibco-developer-hub/templates/well-known-configuration-ingress.yaml
@@ -31,7 +31,7 @@ spec:
             path: /tibco/hub/.well-known/openid-configuration
             pathType: Exact
 ---
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
   name: {{ include "common.names.fullname" . }}-header
@@ -41,7 +41,7 @@ spec:
       X-Forwarded-Proto: "https"
       x-cp-host: {{ $cpHostname }}
 ---
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
   name: {{ include "common.names.fullname" . }}-rewrite


### PR DESCRIPTION
flogoprovisioner: 1.2.15
bwprovisioner: 1.2.18
dp-configure-namespace: 1.2.30
=====
Changing the Traefik apiGroup from traefik.containo.us to traefik.io for better support (v2 and v3)