### PR TITLE
bwprovisioner: 1.2.19

### DIFF
--- a/charts/bwprovisioner/Chart.yaml
+++ b/charts/bwprovisioner/Chart.yaml
@@ -4,7 +4,7 @@
 
 apiVersion: v2
 name: bwprovisioner
-version: 1.2.18
+version: 1.2.19
 appVersion: "1.2.0"
 description: TIBCO Platform Dataplane Capabilty -- BW Provisioner
 home: https://github.com/tibco/tp-iapp-bw-provisioner.git

--- a/charts/bwprovisioner/templates/ingress_public_nginx.yaml
+++ b/charts/bwprovisioner/templates/ingress_public_nginx.yaml
@@ -8,7 +8,8 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    traefik.ingress.kubernetes.io/router.middlewares: {{ .Release.Namespace }}-{{ $fullName }}-auth@kubernetescrd,{{ .Release.Namespace }}-{{ $fullName }}-rewrite@kubernetescrd
+    traefik.ingress.kubernetes.io/router.middlewares: {{ .Release.Namespace }}-{{ $fullName }}-auth@kubernetescrd,{{ .Release.Namespace }}-{{ $fullName }}-rewrite@kubernetescr
+    external-dns.alpha.kubernetes.io/target: {{ .Values.publicApi.ingress.nginx.fqdn }}
   name: {{ $fullName }}-public-nginx
 spec:
   ingressClassName: traefik

--- a/charts/flogoprovisioner/Chart.yaml
+++ b/charts/flogoprovisioner/Chart.yaml
@@ -4,7 +4,7 @@
 
 apiVersion: v2
 name: flogoprovisioner
-version: 1.2.15
+version: 1.2.16
 appVersion: "1.2.0"
 description: TIBCO Platform Dataplane Capabilty -- Flogo Provisioner
 home: https://github.com/tibco/tp-iapp-flogo-provisioner.git

--- a/charts/flogoprovisioner/templates/ingress_public_nginx.yaml
+++ b/charts/flogoprovisioner/templates/ingress_public_nginx.yaml
@@ -8,6 +8,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
+    external-dns.alpha.kubernetes.io/target: {{ .Values.publicApi.ingress.nginx.fqdn }}
     traefik.ingress.kubernetes.io/router.middlewares: {{ .Release.Namespace }}-{{ $fullName }}-auth@kubernetescrd,{{ .Release.Namespace }}-{{ $fullName }}-rewrite@kubernetescrd
   name: {{ $fullName }}-public-nginx
 spec:

--- a/charts/tibco-developer-hub/Chart.yaml
+++ b/charts/tibco-developer-hub/Chart.yaml
@@ -6,8 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.18
-
+version: 1.2.19
 appVersion: "1.2.0"
 
 dependencies:

--- a/charts/tibco-developer-hub/templates/ingress.yaml
+++ b/charts/tibco-developer-hub/templates/ingress.yaml
@@ -16,6 +16,7 @@ metadata:
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   annotations:
+    external-dns.alpha.kubernetes.io/target: {{ .Values.ingress.host }}
     traefik.ingress.kubernetes.io/router.middlewares: {{ .Release.Namespace }}-{{ $fullName }}-auth@kubernetescrd
     {{- if .Values.ingress.annotations }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.ingress.annotations "context" $) | nindent 4 }}

--- a/charts/tibco-developer-hub/templates/well-known-configuration-ingress.yaml
+++ b/charts/tibco-developer-hub/templates/well-known-configuration-ingress.yaml
@@ -16,6 +16,7 @@ metadata:
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   annotations:
+    external-dns.alpha.kubernetes.io/target: {{ .Values.ingress.host }}
     traefik.ingress.kubernetes.io/router.middlewares: {{ .Release.Namespace }}-{{ include "common.names.fullname" . }}-header@kubernetescrd,{{ .Release.Namespace }}-{{ include "common.names.fullname" . }}-rewrite@kubernetescrd
 spec:
   ingressClassName: {{ .Values.ingress.className | quote }}


### PR DESCRIPTION
flogoprovisioenr:  1.2.16
tibco-developer-hub: 1.2.19
===
adding the required annotation: external-dns.alpha.kubernetes.io/target